### PR TITLE
Correcting terminology for retrieving Gravity Form.

### DIFF
--- a/resources/Field.php
+++ b/resources/Field.php
@@ -58,8 +58,8 @@ class Field extends acf_field
             'name'         => 'return_format',
             'layout'       => 'horizontal',
             'choices'      => [
-                'post_object' => __('Post Object', 'acf'),
-                'id'          => __('Post ID', 'acf')
+                'post_object' => __('Form Object', 'acf'),
+                'id'          => __('Form ID', 'acf')
             ],
         ]);
 


### PR DESCRIPTION
Changing from `Page Object` and `Page ID` to `Form Object` and `Form ID`. 