### PR TITLE
Installation and activation links in notices

### DIFF
--- a/resources/Notices.php
+++ b/resources/Notices.php
@@ -42,6 +42,9 @@ class Notices
         }
     }
 
+    /**
+     * Check if there are any active gravityforms forms. If not, issue a notice
+     */
     public function hasActiveGravityForms($inline = '', $alt = '')
     {
         if (!$this->forms) {
@@ -53,7 +56,7 @@ class Notices
     }
 
     /**
-     * Check if gravityforms is active. If not, issue a notice
+     * Check if advanced custom fields is active. If not, issue a notice
      */
     public function isAdvancedCustomFieldsActive($inline = '', $alt = '')
     {

--- a/resources/Notices.php
+++ b/resources/Notices.php
@@ -13,11 +13,20 @@ class Notices
      */
     public $forms;
 
+    /**
+     * Acces utility methods
+     *
+     * @var Utils
+     */
+    public $utils;
+
     public function __construct()
     {
         if (class_exists('GFAPI')) {
             $this->forms = GFAPI::get_forms();
         }
+
+        $this->utils = new Utils();
     }
 
     /**
@@ -30,16 +39,25 @@ class Notices
     }
 
     /**
-     * Check if gravityforms is active. If not, issue a notice
+     * Check if gravityforms is installled and active. If not, issue an activation or installation notice
      */
     public function isGravityFormsActive($inline = '', $alt = '')
     {
-        if (!class_exists('GFAPI')) {
-            $notice = sprintf(__('Warning: You need to <a href="%s">Activate Gravityforms</a> in order to use the Advanced Custom Fields: Gravityforms Add-on.',
-                ACF_GF_FIELD_TEXTDOMAIN), admin_url('plugins.php'));
+        $notice = "";
 
-            $this->createNotice($notice, $inline, $alt);
+        if ($this->utils->isPluginInstalled("Gravity Forms")) {
+            if (!class_exists('GFAPI')) {
+                $activateUrl = $this->utils->generatePluginActivationLinkUrl('gravityforms/gravityforms.php');
+
+                $notice = sprintf(__('Warning: You need to <a href="%s">Activate Gravityforms</a> in order to use the Advanced Custom Fields: Gravityforms Add-on.',
+                    ACF_GF_FIELD_TEXTDOMAIN), $activateUrl);
+            }
+        } else {
+            $notice = sprintf(__('Warning: You need to <a href="%s" target="_blank">Install Gravityforms</a> in order to use the Advanced Custom Fields: Gravityforms Add-on.',
+                ACF_GF_FIELD_TEXTDOMAIN), 'http://www.gravityforms.com');
         }
+        
+        if ($notice) $this->createNotice($notice, $inline, $alt);
     }
 
     /**
@@ -56,16 +74,27 @@ class Notices
     }
 
     /**
-     * Check if advanced custom fields is active. If not, issue a notice
+     * Check if advanced custom fields is installed and active. If not, issue an activation or installation notice
      */
     public function isAdvancedCustomFieldsActive($inline = '', $alt = '')
     {
-        if (!function_exists('get_field')) {
-            $notice = sprintf(__('Warning: You need to <a href="%s">Activate Advanced Custom Fields</a> in order to use the Advanced Custom Fields: Gravityforms Add-on.',
-                ACF_GF_FIELD_TEXTDOMAIN), admin_url('plugins.php'));
+        $notice = "";
 
-            $this->createNotice($notice, $inline, $alt);
+        if ($this->utils->isPluginInstalled("Advanced Custom Fields")) {
+            if (!class_exists('acf')) {
+                $activateUrl = $this->utils->generatePluginActivationLinkUrl('advanced-custom-fields/acf.php');
+
+                $notice = sprintf(__('Warning: You need to <a href="%s">Activate Advanced Custom Fields</a> in order to use the Advanced Custom Fields: Gravityforms Add-on.',
+                    ACF_GF_FIELD_TEXTDOMAIN), $activateUrl);
+            }
+        } else {
+            $installUrl = $this->utils->generatePluginInstallLinkUrl('advanced-custom-fields');
+
+            $notice = sprintf(__('Warning: You need to <a href="%s">Install Advanced Custom Fields</a> in order to use the Advanced Custom Fields: Gravityforms Add-on.',
+                ACF_GF_FIELD_TEXTDOMAIN), $installUrl);
         }
+
+        if ($notice) $this->createNotice($notice, $inline, $alt);
     }
 
     /**

--- a/resources/Utils.php
+++ b/resources/Utils.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace ACFGravityformsField;
+
+
+class Utils
+{
+
+    /**
+     * Generate an activation URL for a plugin like the ones found in WordPress plugin administration screen.
+     *
+     * @param  string $plugin A plugin-folder/plugin-main-file.php path (e.g. "my-plugin/my-plugin.php")
+     *
+     * @return string         The plugin activation url
+     */
+    public function generatePluginActivationLinkUrl($plugin)
+    {
+        // the plugin might be located in the plugin folder directly
+        $plugin = urldecode($plugin);
+        
+        $activateUrl = sprintf(admin_url('plugins.php?action=activate&plugin=%s&plugin_status=all&paged=1&s'), $plugin);
+        
+        // change the plugin request to the plugin to pass the nonce check
+        $activateUrl = wp_nonce_url($activateUrl, 'activate-plugin_' . $plugin);
+        
+        return $activateUrl;
+    }
+
+    /**
+     * Generate an installation URL for a plugin like the ones found in WordPress plugin administration screen.
+     *
+     * @param  string $plugin A plugin-url path (e.g. "plugin-url")
+     *
+     * @return string         The plugin installation url
+     */
+    public function generatePluginInstallLinkUrl($plugin)
+    {   
+        $installUrl = sprintf(admin_url('update.php?action=install-plugin&plugin=%s'), $plugin);
+        
+        // change the plugin request to the plugin to pass the nonce check
+        $installUrl = wp_nonce_url($installUrl, 'install-plugin_' . $plugin);
+        
+        return $installUrl;
+    }
+
+    /**
+     * Checks if a WordPress plugin is installed.
+     *
+     * @param  string  $pluginTitle The plugin title (e.g. "My Plugin")
+     *
+     * @return string/boolean       The plugin file/folder relative to the plugins folder path (e.g. "my-plugin/my-plugin.php") or false
+     */
+    public function isPluginInstalled($pluginTitle)
+    {
+        // get all the plugins
+        $installedPlugins = get_plugins();
+
+        foreach ($installedPlugins as $installedPlugin => $data) {
+
+            // check for the plugin title
+            if ($data['Title'] == $pluginTitle) {
+
+                // return the plugin folder/file
+                return $installedPlugin;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Added utility methods to check wether a plugin is installed and active as well for generating installing/activation links. In the event that a required plugin is not installed, the notice will prompt the user to install the plugin with a link. For ACF, the notice will provide a link that will install the plugin. For GF the notice will provide a link to the plugin's website in a new tab. In the event that a plugin is installed but not active, the notice will a link that will activate the plugin when clicked.