### PR TITLE
Correct composer vendor name for wpackagist

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can also install Advanced Custom Fields: Gravityforms Add-on trough composer
 
 or if you make use of WPackagist
 
-`composer require wpackagist/acf-gravityforms-add-on`
+`composer require wpackagist-plugin/acf-gravityforms-add-on`
 
 ## Using Advanced Custom Fields: Gravityforms Add-on
 


### PR DESCRIPTION
I believe the correct usage of wpackagist is to use "wpackagist-plugin" and not only "wpackagist" as the vendor name.

Using only wpackagist gives error
> Could not find package wpackagist/acf-gravityforms-add-on/ at any version for your minimum-stability (stable).

But using wpackagist-plugin gives a nice
> Using version ^1.2 for wpackagist-plugin/acf-gravityforms-add-on
....