### PR TITLE
Delaying initialization of plugin until WordPress init hook.

### DIFF
--- a/acf-gravityforms-add-on.php
+++ b/acf-gravityforms-add-on.php
@@ -25,4 +25,4 @@ define('ACF_GF_FIELD_RESOURCES', __DIR__ . '/resources/');
 require_once __DIR__ . '/vendor/autoload.php';
 
 // Initiate the field!
-new ACFGravityformsField\Init();
+add_action( 'init', function() { new ACFGravityformsField\Init(); } );


### PR DESCRIPTION
Ran into a problem where this Add-On caused problems with https://github.com/kodie/gravityforms-repeater

After some sleuthing the problem seemed to be with this plugin calling GFAPI::get_forms() before WordPress's init hook had run. 

This commit delays initialization of this plugin until WordPress init, which does not seem to have any effect on this plugin's functionality but resolves the incompatibility with the other add-on. (It's also just not a bad practice to bootstrap on init anyway, unless there's a compelling reason to initialize earlier)