### PR TITLE
Improves performance on sites with many forms and avoids form meta ca…

### DIFF
--- a/resources/Field.php
+++ b/resources/Field.php
@@ -35,9 +35,9 @@ class Field extends acf_field
         // Get our notices up and running
         $this->notices = new Notices();
 
-        if (class_exists('GFAPI')) {
-            $this->forms = GFAPI::get_forms();
-        }
+	    if (class_exists('GFFormsModel')) {
+		    $this->forms = \GFFormsModel::get_forms();
+	    }
 
         // Execute the parent constructor as well
         parent::__construct();
@@ -106,7 +106,7 @@ class Field extends acf_field
         }
 
         foreach ($this->forms as $form) {
-            $choices[$form['id']] = $form['title'];
+            $choices[ $form->id ] = $form->title;
         }
 
         // Override field settings and start rendering

--- a/resources/FieldForV4.php
+++ b/resources/FieldForV4.php
@@ -49,9 +49,9 @@ class FieldForV4 extends acf_field
         // Get our notices up and running
         $this->notices = new Notices();
 
-        if (class_exists('GFAPI')) {
-            $this->forms = GFAPI::get_forms();
-        }
+	    if (class_exists('GFFormsModel')) {
+		    $this->forms = \GFFormsModel::get_forms();
+	    }
 
         // Execute the parent constructor as well
         parent::__construct();
@@ -151,7 +151,7 @@ class FieldForV4 extends acf_field
         }
 
         foreach ($this->forms as $form) {
-            $choices[$form['id']] = $form['title'];
+            $choices[ $form->id ] = $form->title;
         }
 
         // Override field settings and start rendering

--- a/resources/Notices.php
+++ b/resources/Notices.php
@@ -15,8 +15,8 @@ class Notices
 
     public function __construct()
     {
-        if (class_exists('GFAPI')) {
-            $this->forms = GFAPI::get_forms();
+        if (class_exists('GFFormsModel')) {
+            $this->forms = \GFFormsModel::get_forms();
         }
     }
 


### PR DESCRIPTION
…ching issues when form meta is fetched before custom Gravity Forms field types have had a chance to register themselves.

---

GFAPI::get_forms() fetches the entire form object (including the form meta) for each form which causes a huge performance hit on sites with hundreds of forms. GFFormsModel::get_forms() returns only the bare bones form object (which does not include the meta).

Not fetching the form meta also resolves issues where fields of a custom field type will not be properly initialized by Gravity Forms as the plugins which add the custom field type have not yet had an opportunity to register their field types and the form meta is cached on runtime.