### PR TITLE
Move addNotices into admin_init to fix plugin defined fields being cached too early

### DIFF
--- a/resources/Init.php
+++ b/resources/Init.php
@@ -7,7 +7,6 @@ class Init
     public function __construct()
     {
         $this->addHooks();
-        $this->addNotices();
     }
 
     /**
@@ -18,6 +17,7 @@ class Init
         add_action('acf/include_field_types', [$this, 'addField']);
         add_action('acf/register_fields', [$this, 'addFieldforV4']);
         add_action('admin_init', [$this, 'loadTextDomain']);
+        add_action('admin_init', [$this, 'addNotices']);
     }
 
     /**

--- a/resources/Init.php
+++ b/resources/Init.php
@@ -23,7 +23,7 @@ class Init
     /**
      * Initialize the notices
      */
-    private function addNotices()
+    public function addNotices()
     {
         $notices = new Notices();
         $notices->addHooks();

--- a/resources/Init.php
+++ b/resources/Init.php
@@ -14,8 +14,10 @@ class Init
      */
     private function addHooks()
     {
-        add_action('acf/include_field_types', [$this, 'addField']);
-        add_action('acf/register_fields', [$this, 'addFieldforV4']);
+        if (is_admin()) {
+            add_action('acf/include_field_types', [$this, 'addField']);
+            add_action('acf/register_fields', [$this, 'addFieldforV4']);
+        }
         add_action('admin_init', [$this, 'loadTextDomain']);
         add_action('admin_init', [$this, 'addNotices']);
     }


### PR DESCRIPTION
Move `$this->addNotices()` into an `admin_init` hook to get around Gravity Forms meta fields being cached before external plugins have loaded their own custom fields.

Fixes issues: #18, #23, #24, #25

The hooks that the Notices class defines are only `admin_notices` so putting in `admin_init` is safe as `admin_notices` runs after `admin_init`: https://codex.wordpress.org/Plugin_API/Action_Reference
