### PR TITLE
Moving addNotices into admin_init, fixing custom gravity form fields

### DIFF
--- a/resources/Init.php
+++ b/resources/Init.php
@@ -7,7 +7,6 @@ class Init
 	public function __construct()
 	{
 		$this->addHooks();
-		$this->addNotices();
 	}
 
 	/**
@@ -18,6 +17,7 @@ class Init
 		add_action('acf/include_field_types', [$this, 'addField']);
 		add_action('acf/register_fields', [$this, 'addFieldforV4']);
 		add_action('admin_init', [$this, 'loadTextDomain']);
+		add_action('admin_init', [$this, 'addNotices']);
 	}
 
 	/**

--- a/resources/Init.php
+++ b/resources/Init.php
@@ -23,7 +23,7 @@ class Init
 	/**
 	 * Initialize the notices
 	 */
-	private function addNotices()
+	public function addNotices()
 	{
 		$notices = new Notices();
 		$notices->addHooks();


### PR DESCRIPTION
This moves calling the addNotices function from __construct into the admin_init hook. This fixes the issues Custom Gravity Form Fields rendering.