### PR TITLE
make addNotices public to solve warning

### DIFF
--- a/resources/Init.php
+++ b/resources/Init.php
@@ -12,7 +12,7 @@ class Init
 	/**
 	 * Make sure all hooks are being executed.
 	 */
-	private function addHooks()
+	public function addHooks()
 	{
 		add_action('acf/include_field_types', [$this, 'addField']);
 		add_action('acf/register_fields', [$this, 'addFieldforV4']);


### PR DESCRIPTION
Solves 
( ! ) Warning: call_user_func_array() expects parameter 1 to be a valid callback, cannot access private method ACFGravityformsField\Init::addNotices()

![image](https://user-images.githubusercontent.com/50165380/94129839-2cc86b80-fe5c-11ea-8a05-02e69f52636e.png)
