### PR TITLE
fix performance, and possibly plugin conflicts, by not calling get forms directly on every class constructor

### DIFF
--- a/resources/Field.php
+++ b/resources/Field.php
@@ -257,7 +257,7 @@ class Field extends acf_field
 	 */
 	private function get_forms() {
 		if ( empty( $this->forms ) && class_exists('GFFormsModel') ) {
-			$this->forms = GFFormsModel::get_forms();
+			$this->forms = GFAPI::get_forms();
 		}
 		return $this->forms;
 	}

--- a/resources/Field.php
+++ b/resources/Field.php
@@ -256,7 +256,7 @@ class Field extends acf_field
 	 * @return array
 	 */
 	private function get_forms() {
-		if ( empty( $this->forms ) && class_exists('GFFormsModel') ) {
+		if ( empty( $this->forms ) && class_exists('GFAPI') ) {
 			$this->forms = GFAPI::get_forms();
 		}
 		return $this->forms;

--- a/resources/Field.php
+++ b/resources/Field.php
@@ -4,6 +4,7 @@ namespace ACFGravityformsField;
 
 use acf_field;
 use GFAPI;
+use GFFormsModel;
 
 class Field extends acf_field
 {
@@ -19,7 +20,7 @@ class Field extends acf_field
 	 *
 	 * @var array
 	 */
-	public $forms;
+	public $forms = array();
 
 	public function __construct()
 	{
@@ -34,10 +35,6 @@ class Field extends acf_field
 
 		// Get our notices up and running
 		$this->notices = new Notices();
-
-		if (class_exists('GFAPI')) {
-			$this->forms = GFAPI::get_forms();
-		}
 
 		// Execute the parent constructor as well
 		parent::__construct();
@@ -105,7 +102,7 @@ class Field extends acf_field
 			return false;
 		}
 
-		foreach ($this->forms as $form) {
+		foreach ($this->get_forms() as $form) {
 			$choices[ $form['id'] ] = $form['title'];
 		}
 
@@ -244,12 +241,24 @@ class Field extends acf_field
 		}
 
 		// Check if there are forms and set our choices
-		if (!$this->forms) {
+		if (!$this->get_forms()) {
 			$this->notices->hasActiveGravityForms(true, true);
 
 			return false;
 		}
 
 		return true;
+	}
+
+	/**
+	 * Get all forms
+	 *
+	 * @return array
+	 */
+	private function get_forms() {
+		if ( empty( $this->forms ) && class_exists('GFFormsModel') ) {
+			$this->forms = GFFormsModel::get_forms();
+		}
+		return $this->forms;
 	}
 }

--- a/resources/FieldForV4.php
+++ b/resources/FieldForV4.php
@@ -33,7 +33,7 @@ class FieldForV4 extends acf_field
 	 *
 	 * @var array
 	 */
-	public $forms;
+	public $forms = array();
 
 	public function __construct()
 	{
@@ -48,10 +48,6 @@ class FieldForV4 extends acf_field
 
 		// Get our notices up and running
 		$this->notices = new Notices();
-
-		if (class_exists('GFFormsModel')) {
-			$this->forms = GFFormsModel::get_forms();
-		}
 
 		// Execute the parent constructor as well
 		parent::__construct();
@@ -149,7 +145,7 @@ class FieldForV4 extends acf_field
 			return false;
 		}
 
-		foreach ($this->forms as $form) {
+		foreach ($this->get_forms() as $form) {
 			$choices[ $form->id ] = $form->title;
 		}
 
@@ -192,5 +188,17 @@ class FieldForV4 extends acf_field
 	{
 		$fieldObject = new Field();
 		return $fieldObject->processValue($value, $field);
+	}
+
+	/**
+	 * Get all forms
+	 *
+	 * @return array
+	 */
+	private function get_forms() {
+		if ( empty( $this->forms ) && class_exists('GFFormsModel') ) {
+			$this->forms = GFFormsModel::get_forms();
+		}
+		return $this->forms;
 	}
 }

--- a/resources/Notices.php
+++ b/resources/Notices.php
@@ -11,16 +11,13 @@ class Notices
 	 *
 	 * @var array
 	 */
-	public $forms;
+	public $forms = array();
 
 	/**
 	 * Make sure all hooks are being executed.
 	 */
 	public function addHooks()
 	{
-		if (class_exists('GFFormsModel')) {
-			$this->forms = GFFormsModel::get_forms();
-		}
 		add_action('admin_notices', [$this, 'isGravityFormsActive']);
 		add_action('admin_notices', [$this, 'isAdvancedCustomFieldsActive']);
 	}
@@ -45,7 +42,7 @@ class Notices
 	 */
 	public function hasActiveGravityForms($inline = '', $alt = '')
 	{
-		if (!$this->forms) {
+		if (!$this->get_forms()) {
 			$notice = sprintf(__(
 				' Warning: There are no active forms. You need to <a href="%s">Create a New Form</a> in order to use the Advanced Custom Fields: Gravityforms Add-on.',
 				ACF_GF_FIELD_TEXTDOMAIN
@@ -79,5 +76,17 @@ class Notices
 		$alt = $alt ? ' notice-alt' : '';
 
 		echo '<div class="notice notice-warning ' . $inline . $alt . '"><p>' . $notice . '</p></div>';
+	}
+
+	/**
+	 * Get all forms
+	 *
+	 * @return array
+	 */
+	private function get_forms() {
+		if ( empty( $this->forms ) && class_exists('GFFormsModel') ) {
+			$this->forms = GFFormsModel::get_forms();
+		}
+		return $this->forms;
 	}
 }


### PR DESCRIPTION
The get_forms function was called a lot inside of a constructor.
This is kind of okay for small sites, but for a site with 200 forms, this is a large query to do. It's even worse, because GravityForms runs a separate query for each form.

That's why i moved this functionality to a separate function, which will only get the forms once.

This also possibly solves some plugin conflicts, like for example https://github.com/DannyvanHolten/acf-gravityforms-add-on/issues/25 .

I see the checks are failing, but i also see that i may destroy code consistency in your plugin if i try to comply to them.
If you're sure you want me to comply, please let me know.