### PR TITLE
only load all forms once when rendering multiple fields

### DIFF
--- a/resources/Field.php
+++ b/resources/Field.php
@@ -93,7 +93,7 @@ class Field extends acf_field
 	public function render_field($field)
 	{
 
-		if (class_exists('GFAPI')) {
+		if (class_exists('GFAPI') && empty($this->forms)) {
 			$this->forms = GFAPI::get_forms(true, false, 'title');
 		}
 

--- a/resources/FieldForV4.php
+++ b/resources/FieldForV4.php
@@ -136,7 +136,7 @@ class FieldForV4 extends acf_field
 	public function create_field($field)
 	{
 
-		if (class_exists('GFFormsModel')) {
+		if (class_exists('GFFormsModel') && empty($this->forms)) {
 			$this->forms = GFFormsModel::get_forms(true, false, 'title');
 		}
 


### PR DESCRIPTION
Fixes #55 

Fixes performance issue where all forms were loaded from the database every time an acf field was rendered.
On sites with a lot of forms (in our case approx 350) this would result in a lot of database queries and a very high page load time when editing a post/page.